### PR TITLE
Notify around #top_level

### DIFF
--- a/bin/rake_notify
+++ b/bin/rake_notify
@@ -9,7 +9,9 @@ end
 require 'rake'
 require 'rake_notification'
 
-Rake.application.extend RakeNotification
+class Rake::Application
+  prepend RakeNotification
+end
 
 begin
   require RakeNotification.config_path

--- a/lib/rake_notification.rb
+++ b/lib/rake_notification.rb
@@ -17,14 +17,18 @@ module RakeNotification
     notification_interceptors << interceptor
   end
 
-  def run
-    inform_interceptors
+  def top_level
+    inform_interceptors rescue nil
+
     super
-  rescue SystemExit => e
-    inform_observers(e)
-    raise e
+  rescue SystemExit => original_error
+    inform_observers(original_error) rescue raise original_error
+    raise original_error
+  rescue Exception => original_error
+    inform_observers(SystemExit.new(1, original_error.message)) rescue raise original_error
+    raise original_error
   else
-    inform_observers
+    inform_observers rescue nil
   end
 
   private

--- a/spec/lib/rake_notification_spec.rb
+++ b/spec/lib/rake_notification_spec.rb
@@ -8,7 +8,8 @@ describe RakeNotification do
   let(:notifier) { double('notifier') }
 
   before {
-    app.extend described_class
+    class Rake::Application; prepend RakeNotification; end
+
     allow(app).to receive(:invoke_task).and_return(true)
   }
 


### PR DESCRIPTION
`Rake::Application#run` を フックする代わりに `Rake::Application#top_level` をフックする仕様変更を行います。

これにより、フックメソッド内で Rails等の資産を再利用できるようになります
